### PR TITLE
Dependency rework: Use rustls by default, specify MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,10 +72,8 @@ dependencies = [
  "futures-io",
  "futures-util",
  "log",
- "native-tls",
  "pin-project-lite",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
  "webpki-roots",
@@ -303,16 +301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5458d9d1a587efaf5091602c59d299696a3877a439c8f6d461a2d3cce11df87a"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,36 +451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,21 +478,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -720,12 +663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,19 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,26 +775,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -941,12 +845,6 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1044,24 +942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,50 +1020,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1460,13 +1296,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1476,7 +1310,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -1511,20 +1344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ca10b9c9e53ac855a2d6953bce34cef6edbac32c4b13047a4d59d67299420a"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1571,15 +1390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,29 +1415,6 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1696,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
+checksum = "d007dc45584ecc47e791f2a9a7cf17bf98ac386728106f111159c846d624be3f"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -1923,19 +1710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,16 +1826,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2186,7 +1950,6 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand",
  "rustls",
  "sha-1",
@@ -2292,12 +2055,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,6 @@ version = "0.1.0"
 dependencies = [
  "async-ringbuf",
  "async-trait",
- "atty",
  "byteorder",
  "clap",
  "configparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.17"
 regex = "1.6.0"
 ringbuf = "0.3.2"
 simple_logger = { version = "4.0.0", features = ["timestamps","colored","stderr","threads"] }
-songbird = { version = "0.3.2", features = ["serenity-native"] }
+songbird = { version = "0.3.2", features = ["serenity-rustls"] }
 stream-flatten-iters = "0.2.0"
 time = { version = "0.3.17", features = ["local-offset"] }
 tokio = { version = "~1.28", features = ["full"] }
@@ -42,6 +42,6 @@ features = [
     "model",
     "http",
     "utils",
-    "native_tls_backend",
+    "rustls_backend",
     "voice"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Paul Bonnen <hal7df@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"
+rust-version = "1.70.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,7 +15,6 @@ pulse = ["dep:libpulse-binding"]
 [dependencies]
 async-ringbuf = "0.1.2"
 async-trait = "0.1.60"
-atty = "0.2"
 byteorder = "1.4.3"
 clap = { version = "3.2.22", features = ["cargo", "derive"] }
 configparser = "3.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bardcast"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Paul Bonnen <hal7df@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Each audio driver has its own feature flag; the most common servers are enabled
 by default, but can be disabled by passing `--no-default-features` to `cargo`
 and manually specifying the drivers you want.
 
+The minimum supported Rust version for this project is **1.70.0**. This will be
+updated on an as-needed basis.
+
 # Setup
 Unlike most Discord bots, there is no quick link to add bardcast to your
 server -- because bardcast runs on your machine (rather than on a server), you

--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ other OSes and sound servers may be added in the future.
 # Building
 bardcast needs the following libraries available on your system:
 
-  * `libopus` (via [Songbird](https://github.com/serenity-rs/songbird#dependencies)):
-  * openssl (Linux only)
-    * This dependency can be removed by editing `Cargo.toml` to change the
-      SSL implementation for Serenity to use `rustls_backend`.
+  * `libopus` (via [Songbird](https://github.com/serenity-rs/songbird#dependencies))
+  * Linux only
+    * `libpulse` (if using the default `pulse` feature for PulseAudio support)
+      * Debian/Ubuntu: `libpulse-dev`
+      * Fedora: `pulseaudio-libs-devel`
+      * openSUSE: `libpulse-devel`
+      * Arch: `libpulse`
 
 Once these dependencies are installed, simply run `cargo build -r` to create a
 release build of bardcast.
 
 Each audio driver has its own feature flag; the most common servers are enabled
-by default, but can be disabled by passing `--no-default-features` to `cargo`.
+by default, but can be disabled by passing `--no-default-features` to `cargo`
+and manually specifying the drivers you want.
 
 # Setup
 Unlike most Discord bots, there is no quick link to add bardcast to your

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ mod sample_log;
 mod snd;
 mod util;
 
+use std::io::{self, IsTerminal};
 use std::process::ExitCode;
 
-use atty::Stream;
 use clap::{crate_name, crate_version, crate_authors, CommandFactory, Parser};
 use futures::future::{FusedFuture, FutureExt};
 use log::{LevelFilter, debug, info, warn, error};
@@ -114,7 +114,7 @@ fn init_logger(config: &ApplicationConfig, default_log_level: LevelFilter) {
         .with_level(log_level)
         .env()
         .with_local_timestamps()
-        .with_colors(atty::is(Stream::Stderr));
+        .with_colors(io::stderr().is_terminal());
 
     //these third-party modules are very noisy at info level, so make them
     //quieter if not debugging

--- a/src/snd/pulse/context/introspect.rs
+++ b/src/snd/pulse/context/introspect.rs
@@ -15,7 +15,6 @@ use crate::snd::pulse::owned::{
     OwnedSinkInputInfo,
     OwnedSourceInfo
 };
-use crate::util;
 use super::{PulseContextWrapper, PulseResultRef};
 use super::collect;
 
@@ -155,7 +154,7 @@ impl AsyncIntrospector {
         self.do_default(|introspect, result| introspect.get_sink_info_list(move |sink_info| {
             if let Some(_) = collect::filter_list(
                 sink_info,
-                |info| util::opt_is_some_and(&info.name, |name| name.starts_with(&prefix))
+                |info| info.name.as_ref().is_some_and(|name| name.starts_with(&prefix))
             ) {
                 collect::increment(&result);
             }

--- a/src/snd/pulse/intercept.rs
+++ b/src/snd/pulse/intercept.rs
@@ -17,7 +17,6 @@ use log::{debug, error, warn};
 
 use libpulse::error::Code;
 
-use crate::util;
 use super::PulseFailure;
 use super::context::AsyncIntrospector;
 use super::owned::OwnedSinkInfo;
@@ -291,11 +290,9 @@ async fn get_created_virtual_sink<S: ToString>(
     //by appending characters to it, so we do a substring search on the sink
     //name instead of a string comparison.
     introspect.get_sinks().await?.drain(..)
-        .filter(|sink| util::opt_is_some_and(
-            &sink.name,
+        .filter(|sink| sink.name.as_ref().is_some_and(
             |name| name.contains(&sink_name)
-        ) && util::opt_is_some_and(
-            &sink.owner_module,
+        ) && sink.owner_module.as_ref().is_some_and(
             |owner_module| *owner_module == mod_idx
         ))
         .next().ok_or(PulseFailure::Error(Code::NoEntity))

--- a/src/snd/pulse/mod.rs
+++ b/src/snd/pulse/mod.rs
@@ -25,7 +25,6 @@ use libpulse::proplist::properties::{
 };
 
 use crate::cfg::InterceptMode;
-use crate::util;
 use crate::util::task::{TaskSetBuilder, ValueJoinHandle};
 use self::intercept::{Interceptor, CapturingInterceptor, PeekingInterceptor};
 use self::context::{AsyncIntrospector, PulseContextWrapper, SampleConsumer};
@@ -310,7 +309,7 @@ async fn initialize(
         shutdown_rx
     );
 
-    let monitor_mode = util::opt_is_some_and(&config.intercept_mode, |mode| *mode == InterceptMode::Monitor);
+    let monitor_mode = config.intercept_mode.as_ref().is_some_and(|mode| *mode == InterceptMode::Monitor);
 
     // Determine the sink to read audio samples from
     let rec_name = if monitor_mode {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -30,15 +30,3 @@ pub fn check_oneshot_rx(rx: &mut OneshotReceiver<()>) -> bool {
         false
     }
 }
-
-///! Manual reimplementation for [`Option::is_some_and`] for compatibility with
-///! stable Rust versions prior to 1.70.0.
-///!
-///! TODO: This should be removed after support for older versions is dropped.
-pub fn opt_is_some_and<T, F: FnOnce(&T) -> bool>(opt: &Option<T>, predicate: F) -> bool {
-    if let Some(t) = opt.as_ref() {
-        predicate(t)
-    } else {
-        false
-    }
-}


### PR DESCRIPTION
  * Use the rustls implementation for serenity by default, to better align with the rest of the Rust ecosystem
  * Set a minimum supported Rust version (MSRV) of 1.70.0, which allows for the removal of some existing dependencies and code that were added to work around some Rust features that were only stabilized in 1.70.0.
    * Specifically, this helps address [Dependabot alert #1](https://github.com/hal7df/bardcast/security/dependabot/1)
  * Update README to specify the new required external dependencies (including the missed `libpulse` dependency) and the MSRV and its update policy.