### PR TITLE
Improve error handling in the pulse driver

### DIFF
--- a/src/snd/pulse/context/introspect.rs
+++ b/src/snd/pulse/context/introspect.rs
@@ -281,7 +281,7 @@ impl AsyncIntrospector {
 
         self.do_op(move |mut introspect, result| introspect.load_module(&name, &args, move |index| {
             collect::last(&result, index);
-        })).await?.ok_or(Code::Unknown)
+        })).await?.ok_or(Code::NoEntity)
     }
 
     /// Unloads the module with the specified index from the server.

--- a/src/snd/pulse/context/mod.rs
+++ b/src/snd/pulse/context/mod.rs
@@ -48,7 +48,6 @@ use self::async_polyfill::{
     PulseFutureInner,
     StreamReadNotifier
 };
-use super::PulseFailure;
 use crate::util::task::ValueJoinHandle;
 
 // RE-EXPORTS ******************************************************************
@@ -129,7 +128,7 @@ impl PulseContextWrapper {
     pub async fn new(
         server: Option<&str>,
         max_mainloop_interval_usec: Option<u64>
-    ) -> Result<ValueJoinHandle<Self>, PulseFailure> {
+    ) -> Result<ValueJoinHandle<Self>, Code> {
         let (op_queue_tx, op_queue_rx) = mpsc::channel::<ContextThunk>(
             OP_QUEUE_SIZE
         );
@@ -164,7 +163,7 @@ impl PulseContextWrapper {
         &self,
         source_name: impl ToString,
         volume: Option<f64>
-    ) -> Result<ValueJoinHandle<SampleConsumer>, PulseFailure> {
+    ) -> Result<ValueJoinHandle<SampleConsumer>, Code> {
         let mut stream = self.get_connected_stream(source_name.to_string()).await?;
         let (mut sample_tx, sample_rx) = AsyncRb::<u8, HeapRb<u8>>::new(SAMPLE_QUEUE_SIZE).split();
 
@@ -241,7 +240,7 @@ impl PulseContextWrapper {
     async fn get_connected_stream(
         &self,
         source_name: String
-    ) -> Result<Stream, PulseFailure> {
+    ) -> Result<Stream, Code> {
         let (tx, rx) = oneshot::channel();
 
         self.with_ctx(move |ctx| {
@@ -252,12 +251,12 @@ impl PulseContextWrapper {
 
         // Note: stream_fut makes PulseAudio API calls directly, so we need
         // to await it in a local task.
-        let stream_fut = rx.await.map_err(|_| PulseFailure::from(Code::BadState))??;
+        let stream_fut = rx.await.map_err(|_| Code::NoData)??;
         task::spawn_local(stream_fut).await
-            .map_err(|_| PulseFailure::from(Code::Unknown))?
+            .map_err(|_| Code::Killed)?
             .map_err(|state| match state {
-                StreamState::Terminated => PulseFailure::Terminated(0),
-                _ => PulseFailure::from(Code::BadState),
+                StreamState::Terminated => Code::Killed,
+                _ => Code::BadState,
             })
     }
 
@@ -501,12 +500,12 @@ impl MainloopHandle {
 fn pulse_init(
     server: Option<&str>,
     max_mainloop_interval_usec: Option<u64>
-) -> Result<(MainloopHandle, InitializingFuture<ContextState, Context>), PulseFailure> {
-    let mainloop = Mainloop::new().ok_or(PulseFailure::Error(Code::BadState))?;
+) -> Result<(MainloopHandle, InitializingFuture<ContextState, Context>), Code> {
+    let mainloop = Mainloop::new().ok_or(Code::BadState)?;
     let mut ctx = Context::new(
         &mainloop,
         crate_name!(),
-    ).ok_or(PulseFailure::Error(Code::BadState))?;
+    ).ok_or(Code::BadState)?;
 
     //Initiate a connection with a running PulseAudio daemon
     debug!("Connecting to PulseAudio server");
@@ -517,9 +516,7 @@ fn pulse_init(
         server,
         FlagSet::NOAUTOSPAWN,
         None
-    ).map_err(|err| {
-        PulseFailure::Error(Code::try_from(err).unwrap_or(Code::Unknown))
-    })?;
+    ).map_err(|err| Code::try_from(err).unwrap_or(Code::Unknown))?;
 
     //Set up a Future that resolves with the state of the context so
     //dependents can wait until it's ready
@@ -544,7 +541,7 @@ async fn start_context_handler(
     server: Option<&str>,
     max_mainloop_interval_usec: Option<u64>,
     mut op_queue: MpscReceiver<ContextThunk>
-) -> Result<JoinHandle<()>, PulseFailure> {
+) -> Result<JoinHandle<()>, Code> {
     let (mut mainloop_handle, ctx_fut) = pulse_init(
         server,
         max_mainloop_interval_usec
@@ -579,10 +576,10 @@ async fn start_context_handler(
             error!("PulseAudio context failed to connect");
 
             mainloop_handle.stop().await;
-            Err(match state {
-                ContextState::Failed => PulseFailure::from(Code::Unknown),
-                ContextState::Terminated => PulseFailure::Terminated(1),
-                _ => PulseFailure::from(Code::Unknown),
+            Err(if state == ContextState::Terminated {
+                Code::ConnectionTerminated
+            } else {
+                Code::Unknown
             })
         }
     }
@@ -594,14 +591,14 @@ async fn start_context_handler(
 fn create_and_connect_stream(
     ctx: &mut Context,
     source_name: impl AsRef<str>
-) -> Result<InitializingFuture<StreamState, Stream>, PulseFailure> {
+) -> Result<InitializingFuture<StreamState, Stream>, Code> {
     //Technically init_stereo should create a new channel map with the format
     //specifier "front-left,front-right", but due to oddities in the Rust
     //binding for PulseAudio, we have to manually specify the format first. We
     //call init_stereo anyways to make sure we are always using the server's
     //understanding of stereo audio.
     let mut channel_map = ChannelMap::new_from_string("front-left,front-right")
-        .map_err(|_| PulseFailure::from(Code::Invalid))?;
+        .map_err(|_| Code::Invalid)?;
     channel_map.init_stereo();
 
     let mut stream = Stream::new(
@@ -615,7 +612,7 @@ fn create_and_connect_stream(
         Some(source_name.as_ref()),
         None,
         StreamFlagSet::START_UNMUTED
-    )?;
+    ).map_err(|pa_err| Code::try_from(pa_err).unwrap_or(Code::Unknown))?;
 
     Ok(InitializingFuture::from(stream))
 }

--- a/src/snd/pulse/context/mod.rs
+++ b/src/snd/pulse/context/mod.rs
@@ -203,13 +203,10 @@ impl PulseContextWrapper {
                     Ok(PeekResult::Empty) => {
                         trace!("PulseAudio stream had no data");
                     },
-                    Err(e) => {
-                        if let Some(msg) = e.to_string() {
-                            error!("Failed to read audio from PulseAudio: {}", msg);
-                        } else {
-                            error!("Failed to read audio from PulseAudio (code {})", e.0);
-                        }
-                    }
+                    Err(e) => error!(
+                        "Failed to read audio from PulseAudio: {}",
+                        e
+                    ),
                 }
             }
 

--- a/src/snd/pulse/error.rs
+++ b/src/snd/pulse/error.rs
@@ -76,7 +76,7 @@ impl Error for PulseDriverError {
 
 impl Display for ComponentError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FormatError> {
-        write!(f, "Error in pulse driver component '{}': {}", self.0, self.1)
+        write!(f, "Error in driver component '{}': {}", self.0, self.1)
     }
 }
 

--- a/src/snd/pulse/error.rs
+++ b/src/snd/pulse/error.rs
@@ -1,0 +1,87 @@
+///! Error types for the PulseAudio driver.
+
+extern crate libpulse_binding as libpulse;
+
+use std::error::Error;
+use std::fmt::{Display, Error as FormatError, Formatter};
+
+use libpulse::error::{Code, PAErr};
+
+use super::DriverComponent;
+
+// TYPE DEFINITIONS ************************************************************
+
+/// Error conditions that can occur during driver initialization.
+#[derive(Debug, Clone)]
+pub enum PulseDriverError {
+    /// Error that occurred in a driver component.
+    ComponentError(ComponentError),
+
+    /// Error caused by an underlying PulseAudio failure.
+    PulseError(Code),
+
+    /// The driver failed to start due to invalid configuration, with an
+    /// explanation.
+    BadConfig(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentError(DriverComponent, Code);
+
+// TYPE IMPLS ******************************************************************
+impl ComponentError {
+    pub fn new(component: DriverComponent, code: Code) -> Self {
+        ComponentError(component, code)
+    }
+}
+
+// TRAIT IMPLS *****************************************************************
+impl From<ComponentError> for PulseDriverError {
+    fn from(component_err: ComponentError) -> Self {
+        PulseDriverError::ComponentError(component_err)
+    }
+}
+
+impl From<Code> for PulseDriverError {
+    fn from(code: Code) -> Self {
+        PulseDriverError::PulseError(code)
+    }
+}
+
+impl From<PAErr> for PulseDriverError {
+    fn from(pa_err: PAErr) -> Self {
+        PulseDriverError::from(Code::try_from(pa_err).unwrap_or(Code::Unknown))
+    }
+}
+
+impl Display for PulseDriverError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FormatError> {
+        match self {
+            PulseDriverError::ComponentError(e) => e.fmt(f),
+            PulseDriverError::PulseError(code) => write!(f, "PulseAudio error: {}", code),
+            PulseDriverError::BadConfig(reason) => write!(f, "Invalid driver configuration: {}", reason),
+        }
+    }
+}
+
+impl Error for PulseDriverError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let PulseDriverError::PulseError(code) = self {
+            Some(code)
+        } else {
+            None
+        }
+    }
+}
+
+impl Display for ComponentError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FormatError> {
+        write!(f, "Error in pulse driver component '{}': {}", self.0, self.1)
+    }
+}
+
+impl Error for ComponentError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.1)
+    }
+}

--- a/src/snd/pulse/event/error.rs
+++ b/src/snd/pulse/event/error.rs
@@ -7,10 +7,10 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Error as FormatError, Formatter};
 
 use libpulse::context::subscribe::Facility;
+use libpulse::error::Code;
 
 use tokio::sync::broadcast::error::RecvError;
 
-use super::super::PulseFailure;
 use super::{AudioEntity, ChangeEvent, ChangeEntity, EntityInfo};
 
 // TYPE DEFINITIONS ************************************************************
@@ -32,7 +32,7 @@ pub enum MissingEventField {
 /// [`Self::raw_event`].
 #[derive(Clone, Debug)]
 pub struct LookupError<E> {
-    error: PulseFailure,
+    error: Code,
     raw_event: ChangeEvent<E>,
 }
 
@@ -63,7 +63,7 @@ pub enum EventListenerError<E> {
 //TYPE IMPLS *******************************************************************
 impl<E> LookupError<E> {
     /// Creates a new error instance from the given root cause and raw event.
-    pub fn new(error: PulseFailure, raw_event: ChangeEvent<E>) -> Self {
+    pub fn new(error: Code, raw_event: ChangeEvent<E>) -> Self {
         Self {
             error,
             raw_event,
@@ -120,7 +120,7 @@ impl<E: Display + Debug + 'static> Error for EventListenerError<E> {
 }
 
 //CONVERSIONS ******************************************************************
-impl<E> From<LookupError<E>> for PulseFailure {
+impl<E> From<LookupError<E>> for Code {
     fn from(err: LookupError<E>) -> Self {
         err.error
     }

--- a/src/snd/pulse/event/listen.rs
+++ b/src/snd/pulse/event/listen.rs
@@ -1,6 +1,10 @@
 ///! Listener types for consuming audio graph change events from the PulseAudio
 ///! server.
 
+extern crate libpulse_binding as libpulse;
+
+use libpulse::error::Code;
+
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::error::RecvError;
 
@@ -60,7 +64,7 @@ impl<I: EntityInfo> OwnedEventListener<I> {
     async fn new(
         introspect: AsyncIntrospector,
         rx: Receiver<Result<ChangeEvent<ChangeEntity>, LookupError<ChangeEntity>>>
-    ) -> Result<Self, PulseFailure> {
+    ) -> Result<Self, Code> {
         Ok(Self {
             existing: I::lookup_all(&introspect).await?,
             rx,
@@ -142,7 +146,7 @@ impl<I: EntityInfo + 'static> ToFilterMapped<I> for OwnedEventListener<I> {
 pub async fn new_listener<I: EntityInfo>(
     introspect: AsyncIntrospector,
     rx: Receiver<Result<ChangeEvent<ChangeEntity>, LookupError<ChangeEntity>>>
-) -> Result<OwnedEventListener<I>, PulseFailure> {
+) -> Result<OwnedEventListener<I>, Code> {
     OwnedEventListener::new(introspect, rx).await
 }
 

--- a/src/snd/pulse/event/mod.rs
+++ b/src/snd/pulse/event/mod.rs
@@ -24,8 +24,8 @@ use libpulse::context::subscribe::{
     Facility,
     Operation as FacilityOperation
 };
+use libpulse::error::Code;
 
-use super::PulseFailure;
 use super::context::AsyncIntrospector;
 use super::owned::{OwnedSinkInfo, OwnedSinkInputInfo};
 
@@ -48,11 +48,11 @@ pub use self::listen::{
 #[async_trait]
 pub trait EntityInfo: Clone + Send {
     /// Looks up the entity metadata of this type that has the specified index.
-    async fn lookup(introspect: &AsyncIntrospector, idx: u32) -> Result<Self, PulseFailure>;
+    async fn lookup(introspect: &AsyncIntrospector, idx: u32) -> Result<Self, Code>;
 
     /// Looks up all entity metadata of this type currently present in the audio
     /// graph.
-    async fn lookup_all(introspect: &AsyncIntrospector) -> Result<Vec<Self>, PulseFailure>;
+    async fn lookup_all(introspect: &AsyncIntrospector) -> Result<Vec<Self>, Code>;
 
     /// Unwraps an [`AudioEntity`] from the given [`ChangeEntity`] if it wraps
     /// an entity of this type.
@@ -197,11 +197,11 @@ impl From<OwnedSinkInputInfo> for ChangeEntity {
 
 #[async_trait]
 impl EntityInfo for OwnedSinkInfo {
-    async fn lookup(introspect: &AsyncIntrospector, idx: u32) -> Result<Self, PulseFailure> {
+    async fn lookup(introspect: &AsyncIntrospector, idx: u32) -> Result<Self, Code> {
         introspect.get_sink_by_index(idx).await
     }
 
-    async fn lookup_all(introspect: &AsyncIntrospector) -> Result<Vec<Self>, PulseFailure> {
+    async fn lookup_all(introspect: &AsyncIntrospector) -> Result<Vec<Self>, Code> {
         introspect.get_sinks().await
     }
 
@@ -224,11 +224,11 @@ impl EntityInfo for OwnedSinkInfo {
 
 #[async_trait]
 impl EntityInfo for OwnedSinkInputInfo {
-    async fn lookup(introspect: &AsyncIntrospector, idx: u32) -> Result<Self, PulseFailure> {
+    async fn lookup(introspect: &AsyncIntrospector, idx: u32) -> Result<Self, Code> {
         introspect.get_sink_input(idx).await
     }
 
-    async fn lookup_all(introspect: &AsyncIntrospector) -> Result<Vec<Self>, PulseFailure> {
+    async fn lookup_all(introspect: &AsyncIntrospector) -> Result<Vec<Self>, Code> {
         introspect.get_sink_inputs().await
     }
 


### PR DESCRIPTION
* Move the pulse driver error types into a dedicated module.
* Remove `PulseFailure` in favor of more targeted error types:
  * When dealing directly with the PulseAudio API, use the `Code` error type directly, without wrapping it in anything.
  * Introduce a `PulseDriverError` type to use as a public error type to return during driver initialization.
  * Introduce a `ComponentError` type to associate a `Code` with a particular driver component, for better triaging.
* Improve a validation message when attempting to use `peek` or `capture` intercept modes without a stream regex specified.
* Refactor `snd` module error handling:
  * Add `DriverInitError` to more appropriately represent the types of expected error conditions returned from a single driver. Convertible into `DriverStartError`, which covers additional error cases that only occur during the driver selection phase.
  * Make `DriverStartError` and `DriverInitError` both accept `Error` implementations for the `ConnectionError` and `InitializationError` variants, to allow drivers to return their own error types directly, rather than having to worry about manually serializing them first.

Closes #10.