### PR TITLE
Add semantic configuration validation at startup

### DIFF
--- a/src/discord/cfg.rs
+++ b/src/discord/cfg.rs
@@ -2,7 +2,7 @@
 
 use configparser::ini::Ini;
 
-use crate::cfg::{self, Args, Config};
+use crate::cfg::{self, Action, Args, Config, SelectedConsumer};
 
 const SECTION_NAME: &'static str = "discord";
 
@@ -56,5 +56,29 @@ impl<'a> Config<'a> for DiscordConfig {
         cfg::merge_opt(&mut self.voice_channel, other.voice_channel);
         cfg::merge_opt(&mut self.metadata_channel, other.metadata_channel);
         cfg::merge_opt(&mut self.server_id, other.server_id);
+    }
+
+    fn validate_semantics(&self, action: Action) -> Result<(), String> {
+        match action {
+            Action::Run(SelectedConsumer::Discord) => {
+                if self.token.is_none() {
+                    Err(String::from("A Discord bot token is required."))
+                } else if self.server_id.is_none() {
+                    Err(String::from("A Discord server ID is required."))
+                } else if self.voice_channel.is_none() {
+                    Err(String::from("A voice channel name is required."))
+                } else {
+                    Ok(())
+                }
+            },
+            Action::ListServers => {
+                if self.token.is_none() {
+                    Err(String::from("A Discord bot token is required."))
+                } else {
+                    Ok(())
+                }
+            },
+            _ => Ok(())
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         },
         Action::ListServers | Action::Run(_) => {
-            let config = match build_config(args) {
+            let config = match build_config(args, action) {
                 Ok(config) => config,
                 Err(s) => {
                     eprintln!("Error in configuration: {}", s);
@@ -67,7 +67,7 @@ fn main() -> ExitCode {
 /// Consumes a [`cfg::Args`] object and converts it into an
 /// [`cfg::ApplicationConfig`] instance, merging configuration from a specified
 /// config file, if present.
-fn build_config(args: Args) -> Result<ApplicationConfig, String> {
+fn build_config(args: Args, action: Action) -> Result<ApplicationConfig, String> {
     let config: Option<ApplicationConfig> = if let Some(configfile) = &args.configfile {
         Some(ApplicationConfig::from_file(configfile)?)
     } else {
@@ -78,8 +78,12 @@ fn build_config(args: Args) -> Result<ApplicationConfig, String> {
 
     if let Some(mut config_from_file) = config {
         config_from_file.merge(config_from_args);
+        config_from_file.validate_semantics(action)?;
+
         Ok(config_from_file)
     } else {
+        config_from_args.validate_semantics(action)?;
+
         Ok(config_from_args)
     }
 }

--- a/src/snd/pulse/cfg.rs
+++ b/src/snd/pulse/cfg.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use configparser::ini::Ini;
 use regex::Regex;
 
-use crate::cfg::{self, Args, InterceptMode, Config};
+use crate::cfg::{self, Action, Args, InterceptMode, Config};
 use crate::snd::pulse;
 
 // TYPE DEFINITIONS ************************************************************
@@ -124,6 +124,18 @@ impl<'a> Config<'a> for PulseDriverConfig {
         if !other.stream_properties.is_empty() {
             self.stream_properties = other.stream_properties;
         }
+    }
+
+    fn validate_semantics(&self, _: Action) -> Result<(), String> {
+        if let Some(intercept_mode) = self.intercept_mode {
+            if intercept_mode != InterceptMode::Monitor && self.stream_regex.is_none() {
+                return Err(String::from(
+                        "The selected intercept mode requires -E/--stream-regex"
+                ));
+            }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This tacks a new step on to the end of the configuration build phase that allows the various configuration types to validate their semantics (configuration values whose validity depends on how other options are set).

Closes #11.