### PR TITLE
Code and dependency cleanup for the 0.1.1 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.70.0"
 
 [features]
 default = ["pulse"]
-pulse = ["dep:libpulse-binding"]
+pulse = ["dep:libpulse-binding", "dep:itertools"]
 
 [dependencies]
 async-ringbuf = "0.1.2"
@@ -20,7 +20,7 @@ clap = { version = "3.2.22", features = ["cargo", "derive"] }
 configparser = "3.0.2"
 dashmap = "5.4.0"
 futures = "0.3.25"
-itertools = "0.11"
+itertools = { version = "0.11", optional = true }
 libpulse-binding = { version = "2.26.0", optional = true }
 log = "0.4.17"
 regex = "1.6.0"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 ![bardcast](icon/bardcast-icon-text-192px.png)
 
 bardcast is a commandline application that can read audio playing on your system
-and stream it to a Discord voice chat.
+and stream it to a Discord voice chat. Currently, only Unix-like systems running
+PulseAudio are supported, although support for other OSes and sound servers may
+be added in the future.
 
-bardcast currently only supports Unix-like systems running PulseAudio (and
-possibly PipeWire via its PulseAudio compatibility layer), although support for
-other OSes and sound servers may be added in the future.
+**The PulseAudio driver is not currently compatible with PipeWire's
+compatibility layer. For more information, please see
+[issue #9](https://github.com/hal7df/bardcast/issues/9). Native PipeWire support
+is being tracked in [issue #4](https://github.com/hal7df/bardcast/issues/4).**
 
 # Building
 bardcast needs the following libraries available on your system:
@@ -133,3 +136,4 @@ available on Unix systems when built with the `pulse` feature flag.
 | `sink-name` | String | The name of the audio sink to use with `peek` or `monitor` intercept modes. |
 | `sink-index` | u32 | The index of the audio sink to use with `peek` or `monitor` intercept modes. Overrides `sink-name` if both are set (unless `sink-name` is provided as a command line argument). |
 | `volume` | 0.0 to 1.0 | Normalized volume level for the recording stream. |
+| `max-mainloop-interval-usec` | u64 | The maximum interval between mainloop iterations in microseconds. This can be tweaked if the application is becoming too laggy (decreasing the value) or using too much CPU (increasing the value), but ideally there should be no need to tweak this. Defaults to 20000us (20ms). |


### PR DESCRIPTION
- Add a note to the README that the application does not currently work with PipeWire.
- Add documentation on the `max-mainloop-interval-ms` configuration item.
- Only require `itertools` when building the pulse driver (as it is only used by the pulse driver)