### PR TITLE
Fix a few segfaults in the PulseAudio driver upon shutdown

### DIFF
--- a/src/snd/pulse/context/async_polyfill.rs
+++ b/src/snd/pulse/context/async_polyfill.rs
@@ -179,6 +179,18 @@ impl StreamReadNotifier {
     pub fn await_data<'a>(&'a self) -> StreamReadFuture<'a> {
         StreamReadFuture::new(&self.0)
     }
+
+    /// Closes the notifier, and unsets the read callback on the stream. This
+    /// should be done instead of letting the notifier go out of scope
+    /// implicitly, as leaving the read callback set can lead to intermittent
+    /// segfaults.
+    ///
+    /// This is done as a dedicated function to avoid holding a mutable
+    /// reference to the stream during the notifier's lifetime when it is not
+    /// needed, which would also prevent reading data from the stream.
+    pub fn close(self, stream: &mut PulseStream) {
+        stream.set_read_callback(None);
+    }
 }
 
 //IMPL: StreamReadFuture *******************************************************
@@ -206,6 +218,15 @@ impl<'a> Future for StreamReadFuture<'a> {
             self.has_polled = true;
             Poll::Pending
         }
+    }
+}
+
+impl<'a> Drop for StreamReadFuture<'a> {
+    fn drop(&mut self) {
+        //In case the future is cancelled, clear out the Waker to prevent the
+        //stream read callback from potentially accidentally waking a
+        //nonexistent task
+        *self.waker.lock().unwrap() = None;
     }
 }
 
@@ -313,5 +334,14 @@ impl<T: Default> Future for PulseFuture<T> {
             State::Cancelled => Poll::Ready(Err(inner.state)),
             State::Done => Poll::Ready(Ok(mem::take(&mut inner.result))),
         }
+    }
+}
+
+impl<T> Drop for PulseFuture<T> {
+    fn drop(&mut self) {
+        //In case the future is cancelled, clear out the Waker to prevent the
+        //stream read callback from potentially accidentally waking a
+        //nonexistent task
+        self.0.lock().unwrap().waker = None
     }
 }

--- a/src/snd/pulse/context/mod.rs
+++ b/src/snd/pulse/context/mod.rs
@@ -211,6 +211,7 @@ impl PulseContextWrapper {
             }
 
             debug!("Stream handler shutting down");
+            notify.close(&mut stream);
 
             //Tear down the record stream
             if let Err(e) = stream.disconnect() {


### PR DESCRIPTION
A few segfaults were discovered in the PulseAudio driver during application shutdown. While it's hard to say for certain whether these changes resolve the discovered segfaults, they seem to greatly reduce their incidence rate, at a minimum. The fixes involve:

  * Implementing `Drop` for `StreamReadFuture`, `PulseFuture`, and `InitializingFuture`, all of of which pass a `Waker` instance into a PulseAudio callback. If `libpulse` attempts to run the callback after the futures/tasks have been dropped, this results in a segfault.
    * This segfault was only observed with `StreamReadFuture`, however it was fixed for all three future types since they all follow the same pattern.
  * Unsetting the read callback on the audio stream when closing a `StreamReadNotifier`. The exact cause isn't clear, but there appears to be some condition where `libpulse` attempting to call the read callback during application shutdown would result in a segfault (that is distinct from the `Waker` issue described above)