### PR TITLE
Remove PulseFuture in favor of tokio::sync::oneshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bardcast"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-ringbuf",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bardcast"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Paul Bonnen <hal7df@gmail.com>"]
 license = "GPL-3.0-or-later"
 edition = "2021"

--- a/src/snd/pulse/context/async_polyfill.rs
+++ b/src/snd/pulse/context/async_polyfill.rs
@@ -6,14 +6,13 @@ extern crate libpulse_binding as libpulse;
 use std::future::Future;
 use std::marker::{PhantomData, Unpin};
 use std::mem;
-use std::ops::{Deref, DerefMut, FnOnce};
+
 use std::pin::Pin;
-use std::sync::{Arc, LockResult, Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
 use libpulse::context::{Context as PulseContext, State as PulseContextState};
 use libpulse::stream::{Stream as PulseStream, State as PulseStreamState};
-use libpulse::operation::{Operation, State};
 
 //TYPE DEFINITIONS *************************************************************
 
@@ -68,24 +67,6 @@ pub struct StreamReadFuture<'a> {
     waker: &'a Arc<Mutex<Option<Waker>>>,
     has_polled: bool,
 }
-
-/// Inner state for [`PulseFuture`].
-pub struct PulseFutureInner<T> {
-    state: State,
-    waker: Option<Waker>,
-    result: T,
-}
-
-/// A wrapper for a [`PulseFuture`]'s internal state that exposes just the
-/// future's pending result.
-pub struct PulseResultRef<T>(Arc<Mutex<PulseFutureInner<T>>>);
-
-/// Lock guard for [`PulseResultRef`].
-pub struct PulseResultGuard<'a, T>(MutexGuard<'a, PulseFutureInner<T>>);
-
-/// Generic future implementation for asynchronous operations executing in the
-/// libpulse mainloop abstraction.
-pub struct PulseFuture<T>(Arc<Mutex<PulseFutureInner<T>>>);
 
 //IMPL: InitializingFuture *****************************************************
 impl<S: Unpin, T: InitializingEntity<S> + Unpin> From<T> for InitializingFuture<S, T> {
@@ -238,121 +219,5 @@ impl<'a> Drop for StreamReadFuture<'a> {
         //stream read callback from potentially accidentally waking a
         //nonexistent task
         *self.waker.lock().unwrap() = None;
-    }
-}
-
-//IMPL: PulseFuture ************************************************************
-impl<T> PulseFutureInner<T> {
-    /// Creates a new shared state object seeded with the given initial value.
-    pub fn from(initial: T) -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(Self {
-            state: State::Running,
-            waker: None,
-            result: initial,
-        }))
-    }
-
-    /// Calls the given operation with a reference to the pending future result
-    /// that does not expose other state values.
-    pub fn apply<S: ?Sized, F>(
-        this: &Arc<Mutex<Self>>,
-        ctx: &mut PulseContext,
-        op: F
-    ) -> Operation<S>
-    where F: FnOnce(&mut PulseContext, PulseResultRef<T>) -> Operation<S> {
-        op(ctx, PulseResultRef::from(this))
-    }
-
-    /// Determines if the operation associated with this future has terminated.
-    pub fn terminated(&self) -> bool {
-        self.state != State::Running
-    }
-
-    /// Updates the cached operation execution state.
-    pub fn set_state(&mut self, state: State) {
-        self.state = state;
-    }
-
-    /// Wakes the associated future, if it has caused a task to go to sleep.
-    pub fn wake(&self) {
-        if let Some(waker) = &self.waker {
-            waker.wake_by_ref();
-        }
-    }
-}
-
-impl<T: Default> PulseFutureInner<T> {
-    /// Creates a new shared state object seeded with the underlying type's
-    /// `Default` value.
-    pub fn new() -> Arc<Mutex<Self>> {
-        Self::from(T::default())
-    }
-}
-
-impl<T> From<&Arc<Mutex<PulseFutureInner<T>>>> for PulseResultRef<T> {
-    fn from(inner: &Arc<Mutex<PulseFutureInner<T>>>) -> Self {
-        Self(Arc::clone(inner))
-    }
-}
-
-impl<T> PulseResultRef<T> {
-    /// Locks the underlying state object, and returns a guard object that
-    /// unlocks the state object when it is dropped.
-    pub fn lock<'a>(&'a self) -> LockResult<PulseResultGuard<'a, T>> {
-        self.0.lock()
-            .map(|guard| PulseResultGuard::from(guard))
-            .map_err(|poison| PoisonError::new(PulseResultGuard::from(poison.into_inner())))
-    }
-}
-
-impl<'a, T> From<MutexGuard<'a, PulseFutureInner<T>>> for PulseResultGuard<'a, T> {
-    fn from(inner: MutexGuard<'a, PulseFutureInner<T>>) -> Self {
-        Self(inner)
-    }
-}
-
-impl<T> Deref for PulseResultGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0.result
-    }
-}
-
-impl<T> DerefMut for PulseResultGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0.result
-    }
-}
-
-impl<T> From<&Arc<Mutex<PulseFutureInner<T>>>> for PulseFuture<T> {
-    fn from(op: &Arc<Mutex<PulseFutureInner<T>>>) -> Self {
-        Self(Arc::clone(op))
-    }
-}
-
-impl<T: Default> Future for PulseFuture<T> {
-    type Output = Result<T, State>;
-
-    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut inner = self.0.lock().unwrap();
-
-        match inner.state {
-            State::Running => {
-                inner.waker = Some(ctx.waker().clone());
-                Poll::Pending
-            },
-            State::Cancelled => Poll::Ready(Err(inner.state)),
-            State::Done => Poll::Ready(Ok(mem::take(&mut inner.result))),
-        }
-    }
-}
-
-impl<T> Drop for PulseFuture<T> {
-    fn drop(&mut self) {
-        //In case the future is cancelled, clear out the Waker to prevent the
-        //stream read callback from potentially accidentally waking a
-        //nonexistent task
-        self.0.lock().unwrap().waker = None
     }
 }

--- a/src/snd/pulse/context/async_polyfill.rs
+++ b/src/snd/pulse/context/async_polyfill.rs
@@ -6,7 +6,6 @@ extern crate libpulse_binding as libpulse;
 use std::future::Future;
 use std::marker::{PhantomData, Unpin};
 use std::mem;
-
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};

--- a/src/snd/pulse/context/collect.rs
+++ b/src/snd/pulse/context/collect.rs
@@ -1,50 +1,110 @@
 ///! Useful utilities for handling raw responses from the libpulse API and
-///! collecting them into types that can be returned through a
-///! [`super::PulseFuture`].
+///! collecting them into types that can be returned through a result wrapper.
 
 extern crate libpulse_binding as libpulse;
 
+use std::sync::{Mutex, Weak};
+
+use log::error;
 use libpulse::callbacks::ListResult;
 
-use super::PulseResultRef;
 use crate::snd::pulse::owned::IntoOwnedInfo;
 
-/// Stores the given value in the result container.
-pub fn store<T>(result: &PulseResultRef<T>, value: T) {
-    *result.lock().unwrap() = value;
-}
+// TYPE DEFINITIONS ************************************************************
 
-/// Increments the value in the result container.
-pub fn increment(result: &PulseResultRef<usize>) {
-    *result.lock().unwrap() += 1;
-}
+/// Basic trait providing convenience functions for collecting data into a
+/// shared result during an operation callback.
+pub trait CollectResult<T> {
+    /// Core access function to the underlying data. All other Collect traits
+    /// defined in this module have default implementations based on this
+    /// method.
+    fn with(&self, op: impl FnOnce(&mut T));
 
-/// Stores the given value in the result container, if there is not already any
-/// value stored in it.
-pub fn first<T>(result: &PulseResultRef<Option<T>>, value: T) {
-    let mut result = result.lock().unwrap();
-
-    if result.is_none() {
-        *result = Some(value);
+    /// Stores the given value in the underlying result, Overwriting any
+    /// previous value.
+    fn store(&self, value: T) {
+        self.with(|result| *result = value);
     }
 }
 
-/// Stores the given value in the result container, overriding any value that
-/// may have already been present.
-///
-/// This function is similar to [`store`], but it handles a wrapping `Option`
-/// in the underlying result container.
-pub fn last<T>(result: &PulseResultRef<Option<T>>, value: T) {
-    store(result, Some(value));
+/// Extension trait for implementations of [`CollectResult`] that wrap an
+/// [`Option`].
+pub trait CollectOptionalResult<T>: CollectResult<Option<T>> {
+    /// Only stores the given value if no other value has been set thus far.
+    fn first(&self, value: T) {
+        self.with(|result| if result.is_none() {
+            *result = Some(value);
+        });
+    }
+
+    /// Wraps the given value in an `Option` and stores it, overwriting any
+    /// previous value.
+    fn last(&self, value: T) {
+        self.store(Some(value));
+    }
+    
+    /// Attempts to unwrap an info object from a [`ListResult`], storing it in
+    /// the result if and only if the result has a valid info object, and no
+    /// other info objects have already been stored in the result.
+    fn first_info_in_list<I: IntoOwnedInfo<Owned = T>>(
+        &self,
+        info: ListResult<&I>
+    ) {
+        if let ListResult::Item(info) = info {
+            self.first(info.into_owned());
+        }
+    }
 }
+
+/// Extension trait for implementations of [`CollectResult`] that wrap a [`Vec`].
+pub trait CollectListResult<T>: CollectResult<Vec<T>> {
+    /// Appends the given value to the underlying `Vec`.
+    fn push(&self, value: T) {
+        self.with(|result_list| result_list.push(value));
+    }
+    
+    /// Converts the given info object into its owned equivalent before pushing
+    /// to the underyling list.
+    fn push_info<I: IntoOwnedInfo<Owned = T>>(&self, info: &I) {
+        self.push(info.into_owned());
+    }
+
+    /// Attempts to unwrap an info object from a [`ListResult`], appending it to
+    /// the underlying `Vec` if and only if the result has a valid info object.
+    fn push_info_from_list<I: IntoOwnedInfo<Owned = T>>(
+        &self,
+        info: ListResult<&I>
+    ) {
+        if let ListResult::Item(info) = info {
+            self.push_info(info);
+        }
+    }
+}
+
+// TYPE IMPLS ******************************************************************
+impl<T> CollectResult<T> for Weak<Mutex<T>> {
+    fn with(&self, op: impl FnOnce(&mut T)) {
+        if let Some(result) = self.upgrade() {
+            op(&mut result.lock().unwrap());
+        } else {
+            error!("Attempted to collect into dropped result reference");
+        }
+    }
+}
+
+impl<T> CollectOptionalResult<T> for Weak<Mutex<Option<T>>> {}
+
+impl<T> CollectListResult<T> for Weak<Mutex<Vec<T>>> {}
+
+// PUBLIC HELPER FUNCTIONS *****************************************************
 
 /// Converts a [`ListResult`] to an [`Option`] when the [`ListResult`] is an
 /// `Item`.
 ///
 /// [`ListResult`] technically has additional states to notify the consumer when
 /// the end of the list is reached or an error occurs; however, considering that
-/// [`super::PulseFuture`] always watches the state of the associated
-/// [`libpulse::operation::Operation`], client code rarely needs to handle this
+/// [`crate::snd::pulse::context::PulseContextWrapper`] automatically detects
+/// when an operation ceases execution, client code rarely needs to handle this
 /// case.
 pub fn with_list<'a, T>(list_result: ListResult<&'a T>) -> Option<&'a T> {
     if let ListResult::Item(t) = list_result { Some(t) } else { None }
@@ -61,39 +121,4 @@ pub fn filter_list<'a, T, P: Fn(&'a T) -> bool>(
     } else {
         None
     })
-}
-
-/// Converts the given entity info into an owned equivalent and stores it in
-/// the result container, if there is not already any value stored in it.
-///
-/// This accepts the raw info object as a `ListResult` as most underlying
-/// libpulse introspection functions will return the info object as a list, even
-/// if only one was requested.
-pub fn first_info<T: IntoOwnedInfo>(
-    result: &PulseResultRef<Option<T::Owned>>,
-    list_result: ListResult<&T>
-) {
-    if let ListResult::Item(value) = list_result {
-        first(result, value.into_owned());
-    }
-}
-
-/// Appends the given value to the `Vec` stored in the result container.
-pub fn collect<T>(result: &PulseResultRef<Vec<T>>, value: T) {
-    (*result.lock().unwrap()).push(value);
-}
-
-/// Converts the given entity info into an owned equivalent and appends it to
-/// the `Vec` stored in the result container.
-///
-/// This accepts the raw info object as a `ListResult` as most underlying
-/// libpulse introspection functions will return the info object as a list, even
-/// if only one was requested.
-pub fn collect_info<T: IntoOwnedInfo>(
-    result: &PulseResultRef<Vec<T::Owned>>,
-    list_result: ListResult<&T>
-) {
-    if let ListResult::Item(value) = list_result {
-        collect(result, value.into_owned());
-    }
 }

--- a/src/snd/pulse/event/factory.rs
+++ b/src/snd/pulse/event/factory.rs
@@ -29,6 +29,7 @@ use super::*;
 use super::error::{MissingEventField, ResolveError};
 use super::listen;
 use super::super::context::{AsyncIntrospector, PulseContextWrapper};
+use super::super::context::collect::CollectResult;
 use super::super::owned::{OwnedSinkInputInfo, OwnedSinkInfo};
 
 /// The maximum length of the event notification queue, for both the internal
@@ -264,7 +265,7 @@ async fn subscribe(
     entity_types: InterestMaskSet
 ) -> Result<(), Code> {
     ctx_wrap.do_ctx_op_default(move |ctx, result| {
-        ctx.subscribe(entity_types, move |success| *result.lock().unwrap() = success)
+        ctx.subscribe(entity_types, move |success| result.store(success))
     }).await.map_err(
         |_| Code::Killed
     ).and_then(|subscribe_result| if subscribe_result {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,15 +6,29 @@ pub mod io;
 pub mod task;
 
 use log::warn;
-use tokio::sync::watch::Receiver;
+use tokio::sync::oneshot::Sender as OneshotSender;
+use tokio::sync::watch::Receiver as WatchReceiver;
 
-///! Checks whether the given [`Receiver`] for application shutdown has
-///! been issued a shutdown notification without `await`ing.
-pub fn check_shutdown_rx(rx: &mut Receiver<bool>) -> bool {
+/// Checks whether the given [`WatchReceiver`] for application shutdown has
+/// been issued a shutdown notification without `await`ing.
+pub fn check_shutdown_rx(rx: &mut WatchReceiver<bool>) -> bool {
     if let Ok(has_changed) = rx.has_changed() {
         !has_changed || *rx.borrow_and_update()
     } else {
         warn!("Shutdown notifier closed unexpectedly, terminating task");
         false
+    }
+}
+
+/// Attempts to send the provided value on the given channel, if it has not yet
+/// been closed or dropped, returning the value if unsuccessful.
+pub fn opt_oneshot_try_send<T>(
+    tx: &mut Option<OneshotSender<T>>,
+    value: T
+) -> Result<(), T> {
+    if let Some(tx) = tx.take() {
+        tx.send(value)
+    } else {
+        Err(value)
     }
 }


### PR DESCRIPTION
This drops `PulseFuture` and related types from the `async_polyfill` module in favor of tokio's `oneshot` channel, which performs largely the same purpose.

  * Rewrites most of the `collect` module into helper traits that are implemented for `Weak<Mutex<T>>` (which replaces `PulseFutureInner<T>`, allowing for cleaner interaction with the result store.
  * Change `AsyncIntrospector::sink_inputs_for_sink()` to return a list of info objects describing the sink inputs attached to the sink, rather than just their IDs, as with the other introspect functions.
  * Bumps the application version to v0.2.0.

Closes #3.