### PR TITLE
Merge peek and monitor intercept modes

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -46,8 +46,8 @@ pub struct Args {
 
     /// An identifier for the audio output that bardcast should interact with.
     /// The interpretation of this option depends on the selected capture mode.
-    /// Peek mode will use this output for all recorded audio, while monitor
-    /// mode will monitor all audio sent to this sink.
+    /// Monitor mode will either monitor this sink or duplex audio to this
+    /// sink (depending on whether a stream filter is configured).
     ///
     /// The format of this option depends on the underlying audio server, but
     /// will typically be the audio output's system index or name. If not
@@ -166,18 +166,18 @@ pub enum Action {
 /// Represents the approach the application uses to intercept system audio.
 #[derive(Clone, Copy, ValueEnum, Debug, PartialEq)]
 pub enum InterceptMode {
-    /// Capture system audio, preventing it from reaching a hardware audio
+    /// Capture system audio by using a dedicated capture stream. This will
+    /// prevent the original captured audio from being sent to a hardware audio
     /// output.
     Capture,
 
-    /// Capture system audio without preventing it from reaching a hardware
-    /// audio output.
-    Peek,
-
-    /// Rather than capture individual application audio streams, simply monitor
-    /// all sound played via a specific audio output. WARNING: When using this
-    /// mode, be sure the Discord voice chat is not also sending audio to the
-    /// same output, or you will get feedback.
+    /// Capture system audio by monitoring an existing system audio device, or
+    /// by duplexing the audio stream. This will allow audio to be consumed by
+    /// both bardcast and a hardware audio device.
+    ///
+    /// WARNING: This may cause feedback if used without a stream filter if,
+    /// for instance, the same Discord voice chat to which audio is being sent
+    /// is playing audio on the monitored device.
     Monitor,
 }
 
@@ -362,7 +362,6 @@ fn level_filter_from_string(raw: &str) -> Option<LevelFilter> {
 fn capture_mode_from_string(raw: &str) -> Option<InterceptMode> {
     match raw.to_ascii_uppercase().as_str() {
         "CAPTURE" => Some(InterceptMode::Capture),
-        "PEEK" => Some(InterceptMode::Peek),
         "MONITOR" => Some(InterceptMode::Monitor),
         _ => None,
     }

--- a/src/snd/pulse/cfg.rs
+++ b/src/snd/pulse/cfg.rs
@@ -29,9 +29,8 @@ pub struct PulseDriverConfig {
     pub server: Option<String>,
 
     /// The name of the existing sink that bardcast should interact with,
-    /// according to the [`intercept_mode`]. For `Peek` mode, this is the sink
-    /// that audio is routed to after being intercepted. For `Monitor` mode,
-    /// this is the sink that is monitored.
+    /// according to the [`intercept_mode`].  For `Monitor` mode, this is the
+    /// sink that is monitored.
     ///
     /// This is ignored if [`sink_index`] is set.
     pub sink_name: Option<String>,
@@ -41,9 +40,8 @@ pub struct PulseDriverConfig {
     pub volume: Option<f64>,
 
     /// The index of the existing sink that bardcast should interact with,
-    /// according to the [`intercept_mode`]. For `Peek` mode, this is the sink
-    /// that audio is routed to after being intercepted. For `Monitor` mode,
-    /// this is the sink that is monitored.
+    /// according to the [`intercept_mode`]. For `Monitor` mode, this is the
+    /// sink that is monitored.
     ///
     /// This option takes precedence over [`sink_name`] if both are set.
     pub sink_index: Option<u32>,

--- a/src/snd/pulse/intercept.rs
+++ b/src/snd/pulse/intercept.rs
@@ -63,7 +63,7 @@ pub struct CapturingInterceptor {
 /// Implementation of [`Interceptor`] that duplicates application audio streams
 /// before reading them to allow the audio to reach a hardware sink in addition
 /// to being read by bardcast.
-pub struct PeekingInterceptor {
+pub struct DuplexingInterceptor {
     introspect: AsyncIntrospector,
     demux: OwnedSinkInfo,
     rec: OwnedSinkInfo,
@@ -86,8 +86,8 @@ impl CapturingInterceptor {
     }
 }
 
-impl PeekingInterceptor {
-    /// Creates a new `PeekingInterceptor`, using the given sink as the second
+impl DuplexingInterceptor {
+    /// Creates a new `DuplexingInterceptor`, using the given sink as the second
     /// output.
     pub async fn from_sink(
         introspect: &AsyncIntrospector,
@@ -172,7 +172,7 @@ impl Interceptor for CapturingInterceptor {
 }
 
 #[async_trait]
-impl Interceptor for PeekingInterceptor {
+impl Interceptor for DuplexingInterceptor {
     async fn intercept(&mut self, sink_input_id: u32) -> Result<(), Code> {
         self.introspect.move_sink_input_by_index(
             sink_input_id,

--- a/src/snd/pulse/mod.rs
+++ b/src/snd/pulse/mod.rs
@@ -324,7 +324,7 @@ async fn initialize(
                 config
             ).await?).await?;
             
-            warn!("Monitor intercept mode is being used without a stream filter.\
+            warn!("Monitor intercept mode is being used without a stream filter. \
                    This may cause feedback if the output stream is being played\
                    back on the monitored audio device ('{}')", rec_name);
 

--- a/src/snd/pulse/mod.rs
+++ b/src/snd/pulse/mod.rs
@@ -27,7 +27,7 @@ use libpulse::proplist::properties::{
 
 use crate::cfg::InterceptMode;
 use crate::util::task::{TaskSetBuilder, ValueJoinHandle};
-use self::intercept::{Interceptor, CapturingInterceptor, PeekingInterceptor};
+use self::intercept::{Interceptor, CapturingInterceptor, DuplexingInterceptor};
 use self::context::{AsyncIntrospector, PulseContextWrapper, SampleConsumer};
 use self::event::{
     AudioEntity,
@@ -178,9 +178,9 @@ async fn start_stream_intercept(
     event_rx: OwnedEventListener<OwnedSinkInputInfo>,
     matcher: ProplistMatcher,
     config: &PulseDriverConfig,
+    intercept_mode: InterceptMode,
 ) -> Result<ValueJoinHandle<String>, Code> {
     let introspect = AsyncIntrospector::from(ctx);
-    let capture_mode = config.intercept_mode.unwrap_or(InterceptMode::Peek);
 
     debug!("Establishing event listener for application stream intercept");
     let mut event_rx = event_rx.filter_map(move |event| {
@@ -208,16 +208,15 @@ async fn start_stream_intercept(
     });
 
     // Set up the stream interceptor
-    info!("Intercepting matched applications using mode: {:?}", capture_mode);
-    let intercept: Box<dyn Interceptor> = match capture_mode {
-        InterceptMode::Peek => Box::new(PeekingInterceptor::from_sink(
+    info!("Intercepting matched applications using mode: {:?}", intercept_mode);
+    let intercept: Box<dyn Interceptor> = match intercept_mode {
+        InterceptMode::Monitor => Box::new(DuplexingInterceptor::from_sink(
             &introspect,
             &resolve_configured_sink(&introspect, config).await?,
         ).await?),
         InterceptMode::Capture => Box::new(CapturingInterceptor::new(
             &introspect,
         ).await?),
-        _ => panic!("Attempted to start stream intercept with unsupported capture mode"),
     };
 
     let source_name = intercept.source_name();
@@ -296,38 +295,43 @@ async fn initialize(
         shutdown_rx
     );
 
-    let monitor_mode = config.intercept_mode.as_ref().is_some_and(|mode| *mode == InterceptMode::Monitor);
+    let intercept_mode = config.intercept_mode.unwrap_or(InterceptMode::Capture);
 
     // Determine the sink to read audio samples from
-    let rec_name = if monitor_mode {
-        let introspect = AsyncIntrospector::from(&ctx);
+    let rec_name = if let Some(stream_regex) = &config.stream_regex {
+        let props = if config.stream_properties.is_empty() {
+            vec![
+                APPLICATION_NAME,
+                APPLICATION_PROCESS_BINARY,
+            ].iter().map(|x| String::from(*x)).collect()
+        } else {
+            config.stream_properties.clone()
+        };
 
-        introspect.resolve_sink_monitor_name(resolve_configured_sink(
-            &introspect,
-            config
-        ).await?).await?
+        let matcher = ProplistMatcher::new(props, stream_regex.clone());
+        driver_tasks.detaching_insert(start_stream_intercept(
+            &ctx,
+            event_builder.build().await.map_err(|e| DriverComponent::EventHandler.to_error(e))?,
+            matcher,
+            config,
+            intercept_mode
+        ).await.map_err(|e| DriverComponent::Interceptor.to_error(e))?)
     } else {
-        // Application stream intercept should only be used if a filter is present
-        if let Some(stream_regex) = &config.stream_regex {
-            let props = if config.stream_properties.is_empty() {
-                vec![
-                    APPLICATION_NAME,
-                    APPLICATION_PROCESS_BINARY,
-                ].iter().map(|x| String::from(*x)).collect()
-            } else {
-                config.stream_properties.clone()
-            };
-
-            let matcher = ProplistMatcher::new(props, stream_regex.clone());
-            driver_tasks.detaching_insert(start_stream_intercept(
-                &ctx,
-                event_builder.build().await.map_err(|e| DriverComponent::EventHandler.to_error(e))?,
-                matcher,
+        if intercept_mode == InterceptMode::Monitor {
+            let introspect = AsyncIntrospector::from(&ctx);
+            let rec_name = introspect.resolve_sink_monitor_name(resolve_configured_sink(
+                &introspect,
                 config
-            ).await.map_err(|e| DriverComponent::Interceptor.to_error(e))?)
+            ).await?).await?;
+            
+            warn!("Monitor intercept mode is being used without a stream filter.\
+                   This may cause feedback if the output stream is being played\
+                   back on the monitored audio device ('{}')", rec_name);
+
+            rec_name
         } else {
             return Err(PulseDriverError::BadConfig(String::from(
-                "`capture' and `peek' intercept modes require -E/--stream-regex"
+                "The `capture' intercept mode requires -E/--stream-regex"
             )));
         }
     };


### PR DESCRIPTION
This merges the `peek` intercept mode with the `monitor` intercept mode, as their audio flow graphs are essentially the same; the only functional difference is that `peek` supports stream filters, while `monitor` does not. The presence of a stream filter in the application's command line or configuration is now used to distinguish between these two modes.

With this change, `capture` is now the only intercept mode that requires a stream filter.

Closes #16.